### PR TITLE
Add `eslint-plugin` npm keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "keywords": [
     "eslint",
+    "eslint-plugin",
+    "eslintplugin",
     "react",
     "lingui",
     "i18n"


### PR DESCRIPTION
These are the keywords typically used by eslint plugins to make them easier to find / search for.

https://eslint.org/docs/developer-guide/working-with-plugins#share-plugins

Other examples showing this:

* https://github.com/eslint/generator-eslint/blob/e435549283d310b23c297ade3fc9b9283ecb146d/plugin/templates/_package.json#L5
* https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/57d4b5e0aec2d7b3767546227c7d78f22958c13c/package.json#L19