### PR TITLE
breaking: drop support for old versions of Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
   },
   "dependencies": {
     "requireindex": "^1.2.0"
+  },
+  "engines": {
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   }
 }


### PR DESCRIPTION
Matches ESLint Node version support: https://github.com/eslint/eslint/blob/3ae52584296887e5fc5b0267346294bb920a00e6/package.json#L147

Only support active Node versions: https://nodejs.org/en/about/releases/

Allows us to use latest Node/JavaScript features as well as [ESM dependencies](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c).

Since this is a breaking change, ideally it should be merged together with a bunch of other breaking changes for a major version bump.