### PR TITLE
breaking: require ESLint v6+ as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "scripts": {
     "lint": "eslint ."
   },
+  "peerDependencies": {
+    "eslint": ">= 6"
+  },
   "devDependencies": {
     "eslint": "^8.2.0",
     "eslint-plugin-eslint-plugin": "^4.0.2",


### PR DESCRIPTION
Support only the last 3 major versions of ESLint:

https://eslint.org/blog/2019/06/eslint-v6.0.0-released
https://eslint.org/blog/2020/05/eslint-v7.0.0-released
https://eslint.org/blog/2021/10/eslint-v8.0.0-released

This allows us to utilize newer ESLint features.

If desired, we could limit support to only ESLint v7 and v8, depending on how aggressive we want to be. 